### PR TITLE
Update for the Docker Desktop 3.3.x kernels

### DIFF
--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -3,7 +3,7 @@
 # In the last stage, it creates a package, which can be used for
 # testing.
 
-FROM linuxkit/kernel:5.4.39-f39f83d0d475b274938c86eaa796022bfc7063d2-amd64 AS ksrc
+FROM docker/for-desktop-kernel:5.10.25-6594e668feec68f102a58011bb42bd5dc07a7a9b AS ksrc
 
 # Extract headers and compile module
 FROM linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430 AS build


### PR DESCRIPTION
My Docker Desktop 3.3.x kernel is:
```
kernel:
  image: docker/for-desktop-kernel:5.10.25-6594e668feec68f102a58011bb42bd5dc07a7a9b
  cmdline: page_poison=1 vsyscall=emulate panic=1 nospec_store_bypass_disable noibrs
    noibpb no_stf_barrier mitigations=off
```

With this patch I can insert this example module:
```
dave@m1 kernel % docker build -t kernel-module .
[+] Building 55.9s (15/15) FINISHED                                                                                                                                                                                                
 => [internal] load build definition from Dockerfile                                                                                                                                                                          0.0s
 => => transferring dockerfile: 593B                                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430                                                                                                                           2.6s
 => [internal] load metadata for docker.io/docker/for-desktop-kernel:5.10.25-6594e668feec68f102a58011bb42bd5dc07a7a9b                                                                                                         0.0s
 => [auth] linuxkit/alpine:pull token for registry-1.docker.io                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                             0.0s
 => => transferring context: 1.30kB                                                                                                                                                                                           0.0s
 => [build 1/7] FROM docker.io/linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430@sha256:bca9e72a17c1c74cf7b28a397c643048fd055fa096a3edfe1d16365a5307b9d9                                                              48.5s
 => => resolve docker.io/linuxkit/alpine:e2391e0b164c57db9f6c4ae110ee84f766edc430@sha256:bca9e72a17c1c74cf7b28a397c643048fd055fa096a3edfe1d16365a5307b9d9                                                                     0.0s
 => => sha256:bca9e72a17c1c74cf7b28a397c643048fd055fa096a3edfe1d16365a5307b9d9 1.05kB / 1.05kB                                                                                                                                0.0s
 => => sha256:29e5d40040c18c692ed73df24511071725b74956ca1a61fe6056a651d86a13bd 2.72MB / 2.72MB                                                                                                                                0.4s
 => => sha256:9dc19392b78985ea52d8d676e8dcb66c3151a9f8356abf6eeda8bb4338c1a365 171B / 171B                                                                                                                                    0.9s
 => => sha256:63eddd92a3b40ea7a3d1ee833a633f19c137a5fbd1018dfee1ce5ef4c5bdc1cc 2.41kB / 2.41kB                                                                                                                                0.0s
 => => sha256:7cc32ab9389df5693da836fc8b337a2fd8a253b66ec4ba54ffcc845ad4e8f773 2.85kB / 2.85kB                                                                                                                                0.0s
 => => sha256:9e3df9137300d537869be6fcbd44557f77f1888cc45ec2ba9d043089b0866b1e 217B / 217B                                                                                                                                    0.5s
 => => extracting sha256:29e5d40040c18c692ed73df24511071725b74956ca1a61fe6056a651d86a13bd                                                                                                                                     0.1s
 => => sha256:7d2273a8ab5d472ae6b168a5e6010acf3db9ea73ad187271d9e6c25abcb3b128 432.50MB / 432.50MB                                                                                                                           42.9s
 => => sha256:a6fb2f44da087f4d326cd9369015830e50c51b74ac7ea9e2936c2b177d099e5f 1.17kB / 1.17kB                                                                                                                                0.6s
 => => sha256:38bdd8f47c95a4f1e806cf2fc093fc436d53be46cee83bf2f20feb58bdda8737 9.91MB / 9.91MB                                                                                                                                1.6s
 => => extracting sha256:9dc19392b78985ea52d8d676e8dcb66c3151a9f8356abf6eeda8bb4338c1a365                                                                                                                                     0.0s
 => => sha256:11f774c3feab8e3a9198e9a34928e8c1d5e879bb47863c38b06319e178ab4dd3 1.56kB / 1.56kB                                                                                                                                1.6s
 => => extracting sha256:9e3df9137300d537869be6fcbd44557f77f1888cc45ec2ba9d043089b0866b1e                                                                                                                                     0.0s
 => => extracting sha256:a6fb2f44da087f4d326cd9369015830e50c51b74ac7ea9e2936c2b177d099e5f                                                                                                                                     0.0s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                                                                                                      1.8s
 => => sha256:88445d952a66d5ff584998609670e27925169aefbc5b10b0c0dbde8df04f37ae 120.57MB / 120.57MB                                                                                                                           19.7s
 => => sha256:a0ead0414076241a25152a51901aedbe0b85344bfac2684b56bcf4f56744f22f 6.62kB / 6.62kB                                                                                                                                2.5s
 => => extracting sha256:7d2273a8ab5d472ae6b168a5e6010acf3db9ea73ad187271d9e6c25abcb3b128                                                                                                                                     3.0s
 => => extracting sha256:38bdd8f47c95a4f1e806cf2fc093fc436d53be46cee83bf2f20feb58bdda8737                                                                                                                                     0.2s
 => => extracting sha256:11f774c3feab8e3a9198e9a34928e8c1d5e879bb47863c38b06319e178ab4dd3                                                                                                                                     0.0s
 => => extracting sha256:88445d952a66d5ff584998609670e27925169aefbc5b10b0c0dbde8df04f37ae                                                                                                                                     1.6s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                                                                                                     0.0s
 => => extracting sha256:a0ead0414076241a25152a51901aedbe0b85344bfac2684b56bcf4f56744f22f                                                                                                                                     0.0s
 => [ksrc 1/1] FROM docker.io/docker/for-desktop-kernel:5.10.25-6594e668feec68f102a58011bb42bd5dc07a7a9b                                                                                                                      0.0s
 => [build 2/7] RUN apk add build-base elfutils-dev                                                                                                                                                                           1.0s
 => [build 3/7] COPY --from=ksrc /kernel-dev.tar /                                                                                                                                                                            0.2s 
 => [build 4/7] RUN tar xf kernel-dev.tar                                                                                                                                                                                     1.3s 
 => [build 5/7] WORKDIR /kmod                                                                                                                                                                                                 0.0s 
 => [build 6/7] COPY ./* ./                                                                                                                                                                                                   0.0s 
 => [build 7/7] RUN make all                                                                                                                                                                                                  1.0s 
 => exporting to image                                                                                                                                                                                                        1.2s 
 => => exporting layers                                                                                                                                                                                                       1.2s
 => => writing image sha256:5fe6566373f6cee3bc168856f6ebbefc39669219203bf241cce7b6ef144fc325                                                                                                                                  0.0s 
 => => naming to docker.io/library/kernel-module                                                                                                                                                                              0.0s 
                                                                                                                                                                                                                                   
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
dave@m1 kernel % docker run -it --privileged kernel-module

/kmod # insmod example.ko
/kmod # lsmod
Module                  Size  Used by    Tainted: G  
example                16384  0 
grpcfuse               16384  0 
vsock_loopback         16384  0 
vmw_vsock_virtio_transport_common    28672  1 vsock_loopback
vsock                  40960  5 vsock_loopback,vmw_vsock_virtio_transport_common
xfrm_user              40960  1 
xfrm_algo              16384  1 xfrm_user
/kmod # %                                                                                               
```

Signed-off-by: David Scott <dave@recoil.org>